### PR TITLE
feat(clinical): add predictive patient deterioration alerts

### DIFF
--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -15,6 +15,7 @@ import { approveVisit } from './functions/approve-visit/resource';
 import { verifyFamilyAccess } from './functions/verify-family-access/resource';
 import { createNurseValidated } from './functions/create-nurse-validated/resource';
 import { routeOptimizer } from './functions/route-optimizer/resource';
+import { deteriorationDetector } from './functions/deterioration-detector/resource';
 
 /**
  * @see https://docs.amplify.aws/react/build-a-backend/
@@ -33,6 +34,7 @@ const backend = defineBackend({
     verifyFamilyAccess,
     createNurseValidated,
     routeOptimizer,
+    deteriorationDetector,
 });
 
 // Grant Bedrock permissions to AI-powered Lambda functions
@@ -50,6 +52,7 @@ const bedrockPolicy = new PolicyStatement({
 backend.ripsValidator.resources.lambda.addToRolePolicy(bedrockPolicy);
 backend.glosaDefender.resources.lambda.addToRolePolicy(bedrockPolicy);
 backend.rosterArchitect.resources.lambda.addToRolePolicy(bedrockPolicy);
+backend.deteriorationDetector.resources.lambda.addToRolePolicy(bedrockPolicy);
 
 // ============================================
 // AWS LOCATION SERVICE - Route Optimization
@@ -203,6 +206,31 @@ const billingTablePolicy = new PolicyStatement({
 });
 backend.glosaDefender.resources.lambda.addToRolePolicy(billingTablePolicy);
 backend.ripsValidator.resources.lambda.addToRolePolicy(billingTablePolicy);
+
+// deterioration-detector: needs Patient, PatientAssessment, VitalSigns, Notification, Nurse
+backend.deteriorationDetector.resources.lambda.addEnvironment('PATIENT_TABLE_NAME', tables['Patient'].tableName);
+backend.deteriorationDetector.resources.lambda.addEnvironment('PATIENT_ASSESSMENT_TABLE_NAME', tables['PatientAssessment'].tableName);
+backend.deteriorationDetector.resources.lambda.addEnvironment('VITAL_SIGNS_TABLE_NAME', tables['VitalSigns'].tableName);
+backend.deteriorationDetector.resources.lambda.addEnvironment('NOTIFICATION_TABLE_NAME', tables['Notification'].tableName);
+backend.deteriorationDetector.resources.lambda.addEnvironment('NURSE_TABLE_NAME', tables['Nurse'].tableName);
+
+const deteriorationDetectorPolicy = new PolicyStatement({
+    effect: Effect.ALLOW,
+    actions: ['dynamodb:GetItem', 'dynamodb:Query', 'dynamodb:PutItem'],
+    resources: [
+        tables['Patient'].tableArn,
+        `${tables['Patient'].tableArn}/index/*`,
+        tables['PatientAssessment'].tableArn,
+        `${tables['PatientAssessment'].tableArn}/index/*`,
+        tables['VitalSigns'].tableArn,
+        `${tables['VitalSigns'].tableArn}/index/*`,
+        tables['Notification'].tableArn,
+        `${tables['Notification'].tableArn}/index/*`,
+        tables['Nurse'].tableArn,
+        `${tables['Nurse'].tableArn}/index/*`,
+    ],
+});
+backend.deteriorationDetector.resources.lambda.addToRolePolicy(deteriorationDetectorPolicy);
 
 // Apply AWS resource tags to prevent Spring cleaning deletion
 // These tags are inherited by all resources in the stack (DynamoDB, Lambda, Cognito, AppSync, etc.)

--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -164,7 +164,8 @@ const schema = a.schema({
     ]),
     NotificationType: a.enum([
         'VISIT_APPROVED', 'VISIT_REJECTED', 'VISIT_PENDING_REVIEW',
-        'VISIT_AVAILABLE_FOR_FAMILY', 'SHIFT_ASSIGNED', 'SHIFT_CANCELLED'
+        'VISIT_AVAILABLE_FOR_FAMILY', 'SHIFT_ASSIGNED', 'SHIFT_CANCELLED',
+        'DETERIORATION_WARNING', 'DETERIORATION_CRITICAL'
     ]),
 
     // ============================================
@@ -599,6 +600,16 @@ const schema = a.schema({
         .authorization(allow => [allow.authenticated()])
         .handler(a.handler.function('route-optimizer')),
     
+    // AI-powered patient deterioration risk analysis
+    analyzeDeteriorationRisk: a.query()
+        .arguments({
+            patientId: a.id().required(),
+            tenantId: a.id().required()
+        })
+        .returns(a.json())
+        .authorization(allow => [allow.authenticated()])
+        .handler(a.handler.function('deterioration-detector')),
+
     // ============================================
     // PHASE 19: SECURITY ENHANCEMENTS
     // ============================================

--- a/amplify/functions/deterioration-detector/ai-client.ts
+++ b/amplify/functions/deterioration-detector/ai-client.ts
@@ -1,0 +1,288 @@
+import { BedrockRuntimeClient, InvokeModelCommand } from "@aws-sdk/client-bedrock-runtime";
+import { S3Client, GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import { createHash } from 'crypto';
+
+/**
+ * AI Recording structure for VCR-style testing
+ * Stores complete request/response data with metadata
+ */
+interface AIRecording {
+  requestHash: string;
+  modelId: string;
+  timestamp: string;
+  request: {
+    modelId: string;
+    prompt: string;
+    maxTokens: number;
+    temperature?: number;
+  };
+  response: any;
+  latencyMs: number;
+  tokenUsage?: {
+    inputTokens: number;
+    outputTokens: number;
+  };
+}
+
+/**
+ * AI Client Wrapper with VCR-style recording/replay
+ * 
+ * Supports two modes:
+ * - LIVE: Calls real Bedrock API and saves recordings to S3
+ * - RECORDED: Replays previously recorded responses from S3
+ * 
+ * Environment Variables:
+ * - AI_TEST_MODE: 'LIVE' | 'RECORDED' (default: 'LIVE')
+ * - AI_RECORDINGS_S3_BUCKET: S3 bucket for recordings (required)
+ * - AI_RECORDINGS_PREFIX: S3 prefix for recordings (default: 'ai-recordings')
+ */
+export class AIClient {
+  private bedrock: BedrockRuntimeClient;
+  private s3: S3Client;
+  private mode: 'LIVE' | 'RECORDED';
+  private bucket: string;
+  private prefix: string;
+
+  constructor() {
+    this.bedrock = new BedrockRuntimeClient({ region: "us-east-1" });
+    this.s3 = new S3Client({ region: "us-east-1" });
+    
+    // Determine mode from environment variable
+    const envMode = process.env.AI_TEST_MODE?.toUpperCase();
+    this.mode = (envMode === 'LIVE' || envMode === 'RECORDED') ? envMode : 'LIVE';
+    
+    // S3 configuration
+    this.bucket = process.env.AI_RECORDINGS_S3_BUCKET || '';
+    this.prefix = process.env.AI_RECORDINGS_PREFIX || 'ai-recordings';
+
+    // Log initialization
+    console.log(`[AI_CLIENT] Initialized in ${this.mode} mode`);
+    if (this.mode === 'RECORDED' && !this.bucket) {
+      console.warn('[AI_CLIENT] WARNING: RECORDED mode requires AI_RECORDINGS_S3_BUCKET environment variable');
+    }
+  }
+
+  /**
+   * Invoke AI model with recording/replay support
+   * 
+   * @param params - Model invocation parameters
+   * @returns AI model response
+   */
+  async invokeModel(params: {
+    modelId: string;
+    prompt: string;
+    maxTokens: number;
+    temperature?: number;
+  }): Promise<any> {
+    // Compute stable hash for recording lookup
+    const requestHash = this.computeHash(params);
+    const functionName = this.extractFunctionName();
+    const recordingKey = `${this.prefix}/${functionName}/${requestHash}.json`;
+
+    console.log(`[AI_CLIENT] Request hash: ${requestHash}`);
+
+    // RECORDED mode: Load from S3
+    if (this.mode === 'RECORDED') {
+      return await this.loadRecording(recordingKey);
+    }
+
+    // LIVE mode: Call real API and record
+    return await this.invokeLive(params, recordingKey);
+  }
+
+  /**
+   * Invoke real Bedrock API and save recording
+   */
+  private async invokeLive(
+    params: {
+      modelId: string;
+      prompt: string;
+      maxTokens: number;
+      temperature?: number;
+    },
+    recordingKey: string
+  ): Promise<any> {
+    console.log(`[AI_CLIENT] Calling Bedrock API (LIVE mode)`);
+    const startTime = Date.now();
+
+    try {
+      const command = new InvokeModelCommand({
+        modelId: params.modelId,
+        contentType: "application/json",
+        accept: "application/json",
+        body: JSON.stringify({
+          anthropic_version: "bedrock-2023-05-31",
+          max_tokens: params.maxTokens,
+          temperature: params.temperature || 0.7,
+          messages: [
+            {
+              role: "user",
+              content: [{ type: "text", text: params.prompt }]
+            }
+          ]
+        }),
+      });
+
+      const response = await this.bedrock.send(command);
+      const latencyMs = Date.now() - startTime;
+      const responseBody = JSON.parse(new TextDecoder().decode(response.body));
+
+      console.log(`[AI_CLIENT] Bedrock API call completed in ${latencyMs}ms`);
+
+      // Save recording to S3 (if bucket configured)
+      if (this.bucket) {
+        await this.saveRecording(recordingKey, {
+          requestHash: this.computeHash(params),
+          modelId: params.modelId,
+          timestamp: new Date().toISOString(),
+          request: params,
+          response: responseBody,
+          latencyMs,
+          tokenUsage: {
+            inputTokens: responseBody.usage?.input_tokens || 0,
+            outputTokens: responseBody.usage?.output_tokens || 0,
+          }
+        });
+      } else {
+        console.warn('[AI_CLIENT] Skipping recording save: AI_RECORDINGS_S3_BUCKET not configured');
+      }
+
+      return responseBody;
+
+    } catch (error) {
+      console.error('[AI_CLIENT] Bedrock API call failed:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Compute stable SHA-256 hash for request
+   * Uses canonical JSON to ensure deterministic hashing
+   */
+  private computeHash(params: any): string {
+    // Sort keys for canonical JSON representation
+    const canonical = JSON.stringify(params, Object.keys(params).sort());
+    const hash = createHash('sha256').update(canonical).digest('hex');
+    
+    // Return first 16 characters for shorter filenames
+    return hash.substring(0, 16);
+  }
+
+  /**
+   * Load recording from S3
+   * Fails with clear error message if recording not found
+   */
+  private async loadRecording(key: string): Promise<any> {
+    if (!this.bucket) {
+      throw new Error(
+        `[AI_CLIENT] Cannot load recording: AI_RECORDINGS_S3_BUCKET not configured\n` +
+        `Set environment variable: AI_RECORDINGS_S3_BUCKET=ips-erp-test-recordings`
+      );
+    }
+
+    try {
+      console.log(`[AI_CLIENT] Loading recording from S3: ${key}`);
+      
+      const command = new GetObjectCommand({
+        Bucket: this.bucket,
+        Key: key,
+      });
+      
+      const response = await this.s3.send(command);
+      const body = await response.Body?.transformToString();
+      
+      if (!body) {
+        throw new Error('Empty response body from S3');
+      }
+
+      const recording: AIRecording = JSON.parse(body);
+      
+      console.log(
+        `[AI_CLIENT] ✅ Loaded recording: ${key}\n` +
+        `  - Latency: ${recording.latencyMs}ms\n` +
+        `  - Tokens: ${recording.tokenUsage?.inputTokens}/${recording.tokenUsage?.outputTokens}\n` +
+        `  - Timestamp: ${recording.timestamp}`
+      );
+      
+      return recording.response;
+
+    } catch (error: any) {
+      // Provide helpful error message for missing recordings
+      if (error.name === 'NoSuchKey' || error.Code === 'NoSuchKey') {
+        throw new Error(
+          `[AI_CLIENT] ❌ Recording not found: ${key}\n\n` +
+          `This recording does not exist in S3. To create it:\n` +
+          `1. Run tests in LIVE mode first:\n` +
+          `   AI_TEST_MODE=LIVE npm run test:ai:live\n\n` +
+          `2. Or refresh recordings:\n` +
+          `   npm run test:recordings:refresh\n\n` +
+          `Bucket: ${this.bucket}\n` +
+          `Key: ${key}`
+        );
+      }
+
+      // Re-throw other errors
+      console.error('[AI_CLIENT] Failed to load recording:', error);
+      throw new Error(
+        `[AI_CLIENT] Failed to load recording from S3: ${error.message}\n` +
+        `Bucket: ${this.bucket}\n` +
+        `Key: ${key}`
+      );
+    }
+  }
+
+  /**
+   * Save recording to S3
+   */
+  private async saveRecording(key: string, recording: AIRecording): Promise<void> {
+    try {
+      console.log(`[AI_CLIENT] Saving recording to S3: ${key}`);
+      
+      const command = new PutObjectCommand({
+        Bucket: this.bucket,
+        Key: key,
+        Body: JSON.stringify(recording, null, 2),
+        ContentType: 'application/json',
+        Metadata: {
+          'request-hash': recording.requestHash,
+          'model-id': recording.modelId,
+          'latency-ms': recording.latencyMs.toString(),
+          'input-tokens': recording.tokenUsage?.inputTokens.toString() || '0',
+          'output-tokens': recording.tokenUsage?.outputTokens.toString() || '0',
+        }
+      });
+      
+      await this.s3.send(command);
+      
+      console.log(
+        `[AI_CLIENT] ✅ Saved recording: ${key}\n` +
+        `  - Latency: ${recording.latencyMs}ms\n` +
+        `  - Tokens: ${recording.tokenUsage?.inputTokens}/${recording.tokenUsage?.outputTokens}\n` +
+        `  - Size: ${JSON.stringify(recording).length} bytes`
+      );
+
+    } catch (error: any) {
+      console.error('[AI_CLIENT] Failed to save recording:', error);
+      // Don't throw - recording save failure shouldn't break the Lambda
+      console.warn('[AI_CLIENT] Continuing without recording save');
+    }
+  }
+
+  /**
+   * Extract function name from Lambda context or environment
+   * Used for organizing recordings by function
+   */
+  private extractFunctionName(): string {
+    // Try to get from Lambda context (AWS_LAMBDA_FUNCTION_NAME)
+    const functionName = process.env.AWS_LAMBDA_FUNCTION_NAME;
+    
+    if (functionName) {
+      // Extract base name (remove stage suffix if present)
+      // e.g., "roster-architect-test" -> "roster-architect"
+      return functionName.replace(/-test$|-prod$|-dev$/, '');
+    }
+
+    // Fallback: use 'unknown' (shouldn't happen in Lambda)
+    return 'unknown';
+  }
+}

--- a/amplify/functions/deterioration-detector/handler.ts
+++ b/amplify/functions/deterioration-detector/handler.ts
@@ -1,0 +1,362 @@
+import type { Schema } from '../../data/resource';
+import { AIClient } from './ai-client';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, GetCommand, PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+
+const ddbClient = new DynamoDBClient({});
+const docClient = DynamoDBDocumentClient.from(ddbClient);
+
+const PATIENT_TABLE = process.env.PATIENT_TABLE_NAME!;
+const PATIENT_ASSESSMENT_TABLE = process.env.PATIENT_ASSESSMENT_TABLE_NAME!;
+const VITAL_SIGNS_TABLE = process.env.VITAL_SIGNS_TABLE_NAME!;
+const NOTIFICATION_TABLE = process.env.NOTIFICATION_TABLE_NAME!;
+const NURSE_TABLE = process.env.NURSE_TABLE_NAME!;
+
+const aiClient = new AIClient();
+
+/**
+ * Deterioration Detector - AI-Powered Predictive Patient Deterioration Alerts
+ *
+ * Analyzes patient vitals and assessment trends via Bedrock Claude to detect
+ * early clinical deterioration (sepsis, dehydration, respiratory decline, etc.)
+ * BEFORE scores reach critical thresholds.
+ *
+ * Trigger: On-demand GraphQL custom query (analyzeDeteriorationRisk)
+ * Scope: Per-patient analysis (single patient per invocation)
+ */
+
+interface TrendPoint {
+    date: string;
+    value: number;
+}
+
+interface ScaleTrend {
+    scale: string;
+    points: TrendPoint[];
+    direction: 'improving' | 'stable' | 'worsening';
+    latestValue: number;
+    delta: number; // Change from first to last point
+}
+
+function computeTrends(assessments: any[]): ScaleTrend[] {
+    const trends: ScaleTrend[] = [];
+
+    // Sort assessments by date (oldest first for trend calculation)
+    const sorted = [...assessments].sort(
+        (a, b) => new Date(a.assessedAt).getTime() - new Date(b.assessedAt).getTime()
+    );
+
+    const scaleExtractors: Array<{
+        name: string;
+        extract: (a: any) => number | null;
+        lowerIsWorse: boolean;
+    }> = [
+        { name: 'Glasgow (GCS)', extract: a => a.glasgowScore?.total ?? null, lowerIsWorse: true },
+        { name: 'Dolor (EVA)', extract: a => a.painScore ?? null, lowerIsWorse: false },
+        { name: 'Braden', extract: a => a.bradenScore?.total ?? null, lowerIsWorse: true },
+        { name: 'Morse', extract: a => a.morseScore?.total ?? null, lowerIsWorse: false },
+        { name: 'NEWS', extract: a => a.newsScore?.total ?? null, lowerIsWorse: false },
+        { name: 'Barthel', extract: a => a.barthelScore?.total ?? null, lowerIsWorse: true },
+        { name: 'Norton', extract: a => a.nortonScore?.total ?? null, lowerIsWorse: true },
+        { name: 'RASS', extract: a => a.rassScore ?? null, lowerIsWorse: false },
+    ];
+
+    for (const { name, extract, lowerIsWorse } of scaleExtractors) {
+        const points: TrendPoint[] = [];
+        for (const assessment of sorted) {
+            const value = extract(assessment);
+            if (value !== null) {
+                points.push({ date: assessment.assessedAt, value });
+            }
+        }
+
+        if (points.length >= 2) {
+            const first = points[0].value;
+            const last = points[points.length - 1].value;
+            const delta = last - first;
+            const threshold = Math.max(Math.abs(first) * 0.1, 1); // 10% or minimum 1
+
+            let direction: 'improving' | 'stable' | 'worsening';
+            if (Math.abs(delta) <= threshold) {
+                direction = 'stable';
+            } else if (lowerIsWorse) {
+                // Lower is worse (Glasgow, Braden, Barthel, Norton): decreasing = worsening
+                direction = delta < 0 ? 'worsening' : 'improving';
+            } else {
+                // Higher is worse (Pain, Morse, NEWS, RASS): increasing = worsening
+                direction = delta > 0 ? 'worsening' : 'improving';
+            }
+
+            trends.push({ scale: name, points, direction, latestValue: last, delta });
+        }
+    }
+
+    return trends;
+}
+
+export const handler: Schema['analyzeDeteriorationRisk']['functionHandler'] = async (event) => {
+    const { patientId, tenantId: requestedTenantId } = event.arguments;
+
+    // Extract identity and validate role
+    const identity = event.identity as { sub?: string; claims?: Record<string, unknown> } | undefined;
+    const userId = identity?.sub;
+    const tenantId = identity?.claims?.['custom:tenantId'] as string | undefined;
+    const userGroups = identity?.claims?.['cognito:groups'] as string[] || [];
+
+    if (!userGroups.includes('Admin') && !userGroups.includes('ADMIN') &&
+        !userGroups.includes('Nurse') && !userGroups.includes('NURSE')) {
+        console.error(`[SECURITY] Unauthorized AI function access: userId=${userId}, groups=${userGroups}`);
+        throw new Error('Unauthorized: Admin or Nurse role required');
+    }
+
+    if (!tenantId) {
+        throw new Error('Unauthorized: Missing tenant ID');
+    }
+
+    if (!process.env.MODEL_ID) {
+        throw new Error('MODEL_ID environment variable is required');
+    }
+
+    try {
+        // 1. Query patient data
+        const patientResult = await docClient.send(new GetCommand({
+            TableName: PATIENT_TABLE,
+            Key: { id: patientId },
+        }));
+
+        const patient = patientResult.Item;
+        if (!patient || patient.tenantId !== tenantId) {
+            throw new Error('Patient not found or unauthorized');
+        }
+
+        // 2. Query PatientAssessment via byPatient GSI (last 7 days)
+        const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+        const assessmentResult = await docClient.send(new QueryCommand({
+            TableName: PATIENT_ASSESSMENT_TABLE,
+            IndexName: 'byPatient',
+            KeyConditionExpression: 'patientId = :pid AND assessedAt >= :since',
+            ExpressionAttributeValues: {
+                ':pid': patientId,
+                ':since': sevenDaysAgo,
+            },
+            ScanIndexForward: true, // oldest first
+        }));
+
+        const assessments = assessmentResult.Items || [];
+
+        if (assessments.length < 2) {
+            return {
+                hasRisk: false,
+                overallRiskLevel: 'NONE',
+                confidence: 0,
+                message: 'Se requieren al menos 2 evaluaciones en los últimos 7 días para análisis de tendencias.',
+                risks: [],
+                correlations: [],
+                summary: 'Datos insuficientes para análisis predictivo.',
+                assessmentCount: assessments.length,
+            };
+        }
+
+        // 3. Query VitalSigns for same patient/period
+        const vitalsResult = await docClient.send(new QueryCommand({
+            TableName: VITAL_SIGNS_TABLE,
+            IndexName: 'gsi-Patient.vitalSigns',
+            KeyConditionExpression: 'patientId = :pid',
+            ExpressionAttributeValues: {
+                ':pid': patientId,
+            },
+        }));
+
+        const vitals = (vitalsResult.Items || []).filter(
+            (v: any) => v.date >= sevenDaysAgo.split('T')[0]
+        );
+
+        // 4. Compute trends in TypeScript
+        const trends = computeTrends(assessments);
+
+        // 5. Build vitals summary
+        const vitalsSummary = vitals
+            .sort((a: any, b: any) => a.date.localeCompare(b.date))
+            .map((v: any) => `${v.date}: PA ${v.sys}/${v.dia}, SpO2 ${v.spo2}%, FC ${v.hr}${v.temperature ? `, T° ${v.temperature}°C` : ''}${v.note ? ` - ${v.note}` : ''}`)
+            .join('\n');
+
+        // 6. Build trends summary for prompt
+        const trendsSummary = trends.map(t =>
+            `- ${t.scale}: ${t.points.map(p => `${p.value} (${new Date(p.date).toLocaleDateString('es-CO')})`).join(' → ')} | Dirección: ${t.direction} | Delta: ${t.delta > 0 ? '+' : ''}${t.delta}`
+        ).join('\n');
+
+        // 7. Construct Spanish-language prompt
+        const prompt = `Eres un sistema experto de alerta temprana clínica para una IPS de atención domiciliaria en Colombia.
+
+PACIENTE:
+- Nombre: ${patient.name}
+- Edad: ${patient.age || 'No especificada'}
+- Diagnóstico: ${patient.diagnosis || 'No especificado'}
+
+HISTORIAL DE EVALUACIONES CLÍNICAS (últimos 7 días, ${assessments.length} evaluaciones):
+${trendsSummary || 'Sin tendencias calculables'}
+
+SIGNOS VITALES RECIENTES:
+${vitalsSummary || 'Sin signos vitales registrados'}
+
+UMBRALES DE REFERENCIA:
+- Glasgow (GCS): ≤8 CRÍTICO, 9-12 MODERADO, 13-15 Normal
+- Dolor (EVA): ≥7 SEVERO, 4-6 MODERADO, 0-3 LEVE
+- Braden: ≤9 MUY ALTO riesgo UPP, 10-12 ALTO, 13-14 MODERADO
+- Morse: ≥45 ALTO riesgo caídas, 25-44 MODERADO, 0-24 BAJO
+- NEWS: ≥7 ALTO (escalar inmediato), 5-6 MEDIO, 0-4 BAJO
+- Barthel: ≤20 Dependencia total, 21-60 Severa, 61-90 Moderada
+- Norton: ≤14 ALTO riesgo escaras, 15-16 MEDIO
+- RASS: ≥+3 o ≤-4 CRÍTICO
+
+REGLA CRÍTICA DE FALSOS POSITIVOS:
+Si los puntajes están elevados PERO estables (sin tendencia de empeoramiento), NO generes alerta de deterioro.
+Solo alerta cuando hay una TENDENCIA clara de empeoramiento progresivo o correlaciones entre múltiples escalas que sugieran deterioro inminente.
+
+TAREA:
+Analiza las tendencias y correlaciones entre escalas para detectar signos tempranos de:
+- Sepsis (NEWS creciente + signos vitales alterados)
+- Deshidratación (cambios en PA, FC, estado de consciencia)
+- Deterioro respiratorio (SpO2, frecuencia respiratoria)
+- Riesgo de caídas aumentando (Morse + Barthel empeorando)
+- Deterioro neurológico (Glasgow bajando + RASS alterado)
+- Riesgo de úlceras (Braden/Norton bajando + Barthel bajando)
+
+Responde ÚNICAMENTE con JSON válido, sin texto adicional:
+{
+  "hasRisk": boolean,
+  "overallRiskLevel": "NONE" | "LOW" | "MODERATE" | "HIGH" | "CRITICAL",
+  "confidence": 0.0-1.0,
+  "predictedTimeToThreshold": "string en español o null",
+  "risks": [
+    {
+      "type": "string (tipo de deterioro)",
+      "severity": "LOW" | "MODERATE" | "HIGH" | "CRITICAL",
+      "description": "string en español",
+      "affectedScales": ["nombres de escalas"],
+      "recommendedActions": ["acciones en español"]
+    }
+  ],
+  "correlations": [
+    {
+      "scales": ["nombres de escalas correlacionadas"],
+      "pattern": "descripción del patrón en español"
+    }
+  ],
+  "summary": "resumen ejecutivo en español de máximo 3 oraciones"
+}`;
+
+        // 8. Call AI model
+        const responseBody = await aiClient.invokeModel({
+            modelId: process.env.MODEL_ID!,
+            prompt,
+            maxTokens: 2000,
+            temperature: 0.3,
+        });
+
+        // 9. Parse JSON from response
+        const textOutput = responseBody.content[0].text;
+        const jsonMatch = textOutput.match(/\{[\s\S]*\}/);
+        if (!jsonMatch) {
+            throw new Error('No JSON found in AI response');
+        }
+
+        const analysis = JSON.parse(jsonMatch[0]);
+
+        // 10. If risk detected, create notifications
+        if (analysis.hasRisk && (analysis.overallRiskLevel === 'HIGH' || analysis.overallRiskLevel === 'CRITICAL')) {
+            const now = new Date().toISOString();
+            const notificationType = analysis.overallRiskLevel === 'CRITICAL'
+                ? 'DETERIORATION_CRITICAL'
+                : 'DETERIORATION_WARNING';
+            const message = `Alerta de deterioro ${analysis.overallRiskLevel === 'CRITICAL' ? 'CRÍTICO' : 'detectado'}: ${patient.name} - ${analysis.summary?.substring(0, 120) || 'Revise análisis predictivo'}`;
+
+            const recipientUserIds: string[] = [];
+
+            // Notify primary nurse
+            if (patient.primaryNurseId) {
+                const primaryNurseResult = await docClient.send(new GetCommand({
+                    TableName: NURSE_TABLE,
+                    Key: { id: patient.primaryNurseId },
+                }));
+                const primaryNurse = primaryNurseResult.Item;
+                if (primaryNurse?.cognitoSub) {
+                    recipientUserIds.push(primaryNurse.cognitoSub);
+                }
+            }
+
+            // Notify tenant admins
+            const adminResult = await docClient.send(new QueryCommand({
+                TableName: NURSE_TABLE,
+                IndexName: 'gsi-Tenant.nurses',
+                KeyConditionExpression: 'tenantId = :tenantId',
+                FilterExpression: '#role = :adminRole',
+                ExpressionAttributeNames: { '#role': 'role' },
+                ExpressionAttributeValues: {
+                    ':tenantId': tenantId,
+                    ':adminRole': 'ADMIN',
+                },
+            }));
+
+            for (const admin of adminResult.Items || []) {
+                if (admin.cognitoSub && !recipientUserIds.includes(admin.cognitoSub)) {
+                    recipientUserIds.push(admin.cognitoSub);
+                }
+            }
+
+            // Create notification for each recipient
+            for (const recipientId of recipientUserIds) {
+                const notifId = `notif-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+                await docClient.send(new PutCommand({
+                    TableName: NOTIFICATION_TABLE,
+                    Item: {
+                        id: notifId,
+                        tenantId,
+                        userId: recipientId,
+                        type: notificationType,
+                        message,
+                        entityType: 'Patient',
+                        entityId: patientId,
+                        read: false,
+                        createdAt: now,
+                        updatedAt: now,
+                    },
+                }));
+            }
+        }
+
+        // 11. Return full analysis
+        return {
+            ...analysis,
+            patientId,
+            patientName: patient.name,
+            assessmentCount: assessments.length,
+            vitalsCount: vitals.length,
+            analyzedAt: new Date().toISOString(),
+            trends: trends.map(t => ({
+                scale: t.scale,
+                direction: t.direction,
+                latestValue: t.latestValue,
+                delta: t.delta,
+                pointCount: t.points.length,
+            })),
+        };
+
+    } catch (error) {
+        console.error('Deterioration analysis failed:', error);
+
+        if (error instanceof Error && error.message.includes('Unauthorized')) {
+            throw error;
+        }
+
+        return {
+            hasRisk: false,
+            overallRiskLevel: 'NONE',
+            confidence: 0,
+            error: error instanceof Error ? error.message : 'Unknown error',
+            summary: 'Error en el análisis predictivo. Intente nuevamente.',
+            risks: [],
+            correlations: [],
+        };
+    }
+};

--- a/amplify/functions/deterioration-detector/resource.ts
+++ b/amplify/functions/deterioration-detector/resource.ts
@@ -1,0 +1,9 @@
+import { defineFunction } from '@aws-amplify/backend';
+
+export const deteriorationDetector = defineFunction({
+    name: 'deterioration-detector',
+    timeoutSeconds: 60,
+    environment: {
+        MODEL_ID: 'anthropic.claude-3-5-sonnet-20240620-v1:0'
+    }
+});

--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -110,6 +110,28 @@ function getNotificationStyle(type: NotificationType): {
           </svg>
         ),
       };
+    case 'DETERIORATION_WARNING':
+      return {
+        bgColor: 'bg-amber-50',
+        textColor: 'text-amber-800',
+        borderColor: 'border-amber-200',
+        icon: (
+          <svg className="w-5 h-5 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z" />
+          </svg>
+        ),
+      };
+    case 'DETERIORATION_CRITICAL':
+      return {
+        bgColor: 'bg-red-50',
+        textColor: 'text-red-800',
+        borderColor: 'border-red-200',
+        icon: (
+          <svg className="w-5 h-5 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z" />
+          </svg>
+        ),
+      };
     default:
       return {
         bgColor: 'bg-slate-50',
@@ -246,6 +268,12 @@ export const NotificationBell: React.FC<NotificationBellProps> = ({ userId, onNo
       if (notification.type === 'VISIT_REJECTED') {
         console.log('VISIT_REJECTED clicked - entityId:', notification.entityId,
           '- Parent should navigate to rejected visit for correction');
+      }
+
+      // Log specific action for deterioration alerts
+      if (notification.type === 'DETERIORATION_WARNING' || notification.type === 'DETERIORATION_CRITICAL') {
+        console.log('Deterioration alert clicked - patientId:', notification.entityId,
+          '- Parent should navigate to patient dashboard');
       }
     }
   }, [markAsRead, onNotificationClick]);

--- a/src/components/PatientDashboard.tsx
+++ b/src/components/PatientDashboard.tsx
@@ -2,7 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { client, MOCK_USER } from '../amplify-utils';
 import { usePagination } from '../hooks/usePagination';
 import { type Patient, type Medication, type Task } from '../types';
-import { AssessmentForm, AssessmentHistory } from './clinical';
+import { AssessmentForm, AssessmentHistory, DeteriorationRiskPanel } from './clinical';
+import type { DeteriorationAnalysis } from './clinical';
 import { Person, Medicines, Stethoscope } from 'healthicons-react/outline';
 
 export const PatientDashboard: React.FC = () => {
@@ -11,6 +12,8 @@ export const PatientDashboard: React.FC = () => {
     const [medications, setMedications] = useState<Medication[]>([]);
     const [tasks, setTasks] = useState<Task[]>([]);
     const [showAssessmentForm, setShowAssessmentForm] = useState(false);
+    const [deteriorationAnalysis, setDeteriorationAnalysis] = useState<DeteriorationAnalysis | null>(null);
+    const [isAnalyzing, setIsAnalyzing] = useState(false);
 
     const tenantId = MOCK_USER.attributes['custom:tenantId'];
     const nurseId = MOCK_USER.attributes.sub;
@@ -84,6 +87,32 @@ export const PatientDashboard: React.FC = () => {
             id: selectedPatient.id,
             tasks: updatedTasks
         });
+    };
+
+    const handleAnalyzeDeteriorationRisk = async () => {
+        if (!selectedPatient) return;
+        setIsAnalyzing(true);
+        setDeteriorationAnalysis(null);
+        try {
+            const result = await (client.queries as any).analyzeDeteriorationRisk({
+                patientId: selectedPatient.id,
+                tenantId,
+            });
+            setDeteriorationAnalysis(result?.data ?? result);
+        } catch (error) {
+            console.error('Deterioration analysis failed:', error);
+            setDeteriorationAnalysis({
+                hasRisk: false,
+                overallRiskLevel: 'NONE',
+                confidence: 0,
+                risks: [],
+                correlations: [],
+                summary: 'Error al realizar el analisis.',
+                error: error instanceof Error ? error.message : 'Error desconocido',
+            });
+        } finally {
+            setIsAnalyzing(false);
+        }
     };
 
     if (!selectedPatient) {
@@ -204,13 +233,31 @@ export const PatientDashboard: React.FC = () => {
                     <section className="assessment-section glass">
                         <div className="section-header">
                             <h3>Evaluaciones Clínicas</h3>
-                            <button
-                                onClick={() => setShowAssessmentForm(!showAssessmentForm)}
-                                className="px-3 py-1.5 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 transition-colors"
-                            >
-                                {showAssessmentForm ? 'Ver Historial' : 'Nueva Evaluación'}
-                            </button>
+                            <div className="flex gap-2">
+                                <button
+                                    onClick={handleAnalyzeDeteriorationRisk}
+                                    disabled={isAnalyzing}
+                                    className="px-3 py-1.5 text-sm font-medium text-white bg-amber-600 rounded-md hover:bg-amber-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                                >
+                                    {isAnalyzing ? 'Analizando...' : 'Analizar Riesgo de Deterioro'}
+                                </button>
+                                <button
+                                    onClick={() => setShowAssessmentForm(!showAssessmentForm)}
+                                    className="px-3 py-1.5 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 transition-colors"
+                                >
+                                    {showAssessmentForm ? 'Ver Historial' : 'Nueva Evaluación'}
+                                </button>
+                            </div>
                         </div>
+
+                        {deteriorationAnalysis && (
+                            <div className="mb-4">
+                                <DeteriorationRiskPanel
+                                    analysis={deteriorationAnalysis}
+                                    onDismiss={() => setDeteriorationAnalysis(null)}
+                                />
+                            </div>
+                        )}
 
                         {showAssessmentForm ? (
                             <AssessmentForm

--- a/src/components/clinical/DeteriorationRiskPanel.tsx
+++ b/src/components/clinical/DeteriorationRiskPanel.tsx
@@ -1,0 +1,202 @@
+import React from 'react';
+
+interface DeteriorationRisk {
+    type: string;
+    severity: 'LOW' | 'MODERATE' | 'HIGH' | 'CRITICAL';
+    description: string;
+    affectedScales: string[];
+    recommendedActions: string[];
+}
+
+interface Correlation {
+    scales: string[];
+    pattern: string;
+}
+
+interface TrendInfo {
+    scale: string;
+    direction: 'improving' | 'stable' | 'worsening';
+    latestValue: number;
+    delta: number;
+    pointCount: number;
+}
+
+export interface DeteriorationAnalysis {
+    hasRisk: boolean;
+    overallRiskLevel: 'NONE' | 'LOW' | 'MODERATE' | 'HIGH' | 'CRITICAL';
+    confidence: number;
+    predictedTimeToThreshold?: string | null;
+    risks: DeteriorationRisk[];
+    correlations: Correlation[];
+    summary: string;
+    patientName?: string;
+    assessmentCount?: number;
+    vitalsCount?: number;
+    analyzedAt?: string;
+    trends?: TrendInfo[];
+    error?: string;
+}
+
+interface DeteriorationRiskPanelProps {
+    analysis: DeteriorationAnalysis;
+    onDismiss: () => void;
+}
+
+const RISK_COLORS: Record<string, { bg: string; border: string; text: string; badge: string }> = {
+    NONE: { bg: 'bg-green-50', border: 'border-green-200', text: 'text-green-800', badge: 'bg-green-100 text-green-800' },
+    LOW: { bg: 'bg-blue-50', border: 'border-blue-200', text: 'text-blue-800', badge: 'bg-blue-100 text-blue-800' },
+    MODERATE: { bg: 'bg-amber-50', border: 'border-amber-200', text: 'text-amber-800', badge: 'bg-amber-100 text-amber-800' },
+    HIGH: { bg: 'bg-orange-50', border: 'border-orange-200', text: 'text-orange-800', badge: 'bg-orange-100 text-orange-800' },
+    CRITICAL: { bg: 'bg-red-50', border: 'border-red-200', text: 'text-red-800', badge: 'bg-red-100 text-red-800' },
+};
+
+const SEVERITY_LABELS: Record<string, string> = {
+    NONE: 'Sin Riesgo',
+    LOW: 'Bajo',
+    MODERATE: 'Moderado',
+    HIGH: 'Alto',
+    CRITICAL: 'Critico',
+};
+
+const DIRECTION_ICONS: Record<string, { icon: string; color: string }> = {
+    improving: { icon: '\u2193', color: 'text-green-600' },
+    stable: { icon: '\u2192', color: 'text-slate-500' },
+    worsening: { icon: '\u2191', color: 'text-red-600' },
+};
+
+export const DeteriorationRiskPanel: React.FC<DeteriorationRiskPanelProps> = ({ analysis, onDismiss }) => {
+    const riskColor = RISK_COLORS[analysis.overallRiskLevel] || RISK_COLORS.NONE;
+    const confidencePercent = Math.round((analysis.confidence || 0) * 100);
+
+    return (
+        <div className={`rounded-xl border-2 ${riskColor.border} ${riskColor.bg} p-4 space-y-4`}>
+            {/* Header */}
+            <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                    <span className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-bold ${riskColor.badge}`}>
+                        {SEVERITY_LABELS[analysis.overallRiskLevel] || analysis.overallRiskLevel}
+                    </span>
+                    {confidencePercent > 0 && (
+                        <span className="text-sm text-slate-500">
+                            Confianza: {confidencePercent}%
+                        </span>
+                    )}
+                    {analysis.predictedTimeToThreshold && (
+                        <span className="text-sm text-slate-600 font-medium">
+                            Tiempo estimado: {analysis.predictedTimeToThreshold}
+                        </span>
+                    )}
+                </div>
+                <button
+                    onClick={onDismiss}
+                    className="p-1 text-slate-400 hover:text-slate-600 rounded-full hover:bg-white/50 transition-colors"
+                    aria-label="Cerrar"
+                >
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+
+            {/* Summary */}
+            <p className={`text-sm font-medium ${riskColor.text}`}>
+                {analysis.summary}
+            </p>
+
+            {/* Error state */}
+            {analysis.error && (
+                <div className="bg-red-100 border border-red-200 rounded-lg p-3">
+                    <p className="text-sm text-red-700">Error: {analysis.error}</p>
+                </div>
+            )}
+
+            {/* Trends */}
+            {analysis.trends && analysis.trends.length > 0 && (
+                <div>
+                    <h4 className="text-sm font-semibold text-slate-700 mb-2">Tendencias ({analysis.assessmentCount} evaluaciones, {analysis.vitalsCount} registros de signos vitales)</h4>
+                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                        {analysis.trends.map((trend) => {
+                            const dir = DIRECTION_ICONS[trend.direction] || DIRECTION_ICONS.stable;
+                            return (
+                                <div key={trend.scale} className="bg-white/70 rounded-lg px-3 py-2 text-center">
+                                    <p className="text-xs text-slate-500 truncate">{trend.scale}</p>
+                                    <p className="text-lg font-bold text-slate-800">{trend.latestValue}</p>
+                                    <p className={`text-xs font-medium ${dir.color}`}>
+                                        {dir.icon} {trend.delta > 0 ? '+' : ''}{trend.delta}
+                                    </p>
+                                </div>
+                            );
+                        })}
+                    </div>
+                </div>
+            )}
+
+            {/* Risk cards */}
+            {analysis.risks && analysis.risks.length > 0 && (
+                <div>
+                    <h4 className="text-sm font-semibold text-slate-700 mb-2">Riesgos Detectados</h4>
+                    <div className="space-y-2">
+                        {analysis.risks.map((risk, i) => {
+                            const sevColor = RISK_COLORS[risk.severity] || RISK_COLORS.LOW;
+                            return (
+                                <div key={i} className="bg-white/80 rounded-lg p-3 border border-slate-100">
+                                    <div className="flex items-center gap-2 mb-1">
+                                        <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-bold ${sevColor.badge}`}>
+                                            {risk.severity}
+                                        </span>
+                                        <span className="text-sm font-semibold text-slate-800">{risk.type}</span>
+                                    </div>
+                                    <p className="text-sm text-slate-600 mb-2">{risk.description}</p>
+                                    {risk.affectedScales.length > 0 && (
+                                        <div className="flex flex-wrap gap-1 mb-2">
+                                            {risk.affectedScales.map((scale) => (
+                                                <span key={scale} className="inline-flex px-2 py-0.5 bg-slate-100 text-slate-600 rounded text-xs">
+                                                    {scale}
+                                                </span>
+                                            ))}
+                                        </div>
+                                    )}
+                                    {risk.recommendedActions.length > 0 && (
+                                        <ul className="list-disc list-inside text-xs text-slate-500 space-y-0.5">
+                                            {risk.recommendedActions.map((action, j) => (
+                                                <li key={j}>{action}</li>
+                                            ))}
+                                        </ul>
+                                    )}
+                                </div>
+                            );
+                        })}
+                    </div>
+                </div>
+            )}
+
+            {/* Correlations */}
+            {analysis.correlations && analysis.correlations.length > 0 && (
+                <div>
+                    <h4 className="text-sm font-semibold text-slate-700 mb-2">Correlaciones Detectadas</h4>
+                    <div className="space-y-2">
+                        {analysis.correlations.map((corr, i) => (
+                            <div key={i} className="bg-white/70 rounded-lg p-3 border border-slate-100">
+                                <div className="flex flex-wrap gap-1 mb-1">
+                                    {corr.scales.map((scale) => (
+                                        <span key={scale} className="inline-flex px-2 py-0.5 bg-indigo-50 text-indigo-700 rounded text-xs font-medium">
+                                            {scale}
+                                        </span>
+                                    ))}
+                                </div>
+                                <p className="text-sm text-slate-600">{corr.pattern}</p>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            {/* Footer */}
+            {analysis.analyzedAt && (
+                <p className="text-xs text-slate-400 text-right">
+                    Analizado: {new Date(analysis.analyzedAt).toLocaleString('es-CO')}
+                </p>
+            )}
+        </div>
+    );
+};

--- a/src/components/clinical/index.ts
+++ b/src/components/clinical/index.ts
@@ -7,3 +7,5 @@
 export { AssessmentForm } from './AssessmentForm';
 export { AssessmentHistory } from './AssessmentHistory';
 export { RiskIndicatorBadge } from './RiskIndicatorBadge';
+export { DeteriorationRiskPanel } from './DeteriorationRiskPanel';
+export type { DeteriorationAnalysis } from './DeteriorationRiskPanel';

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -217,7 +217,9 @@ export interface VisitSummary {
 export type NotificationType =
   | 'VISIT_APPROVED'
   | 'VISIT_REJECTED'
-  | 'VISIT_PENDING_REVIEW';
+  | 'VISIT_PENDING_REVIEW'
+  | 'DETERIORATION_WARNING'
+  | 'DETERIORATION_CRITICAL';
 
 /**
  * Notification item for workflow events.


### PR DESCRIPTION
## Summary
- Add AI-powered deterioration detection Lambda (`deterioration-detector`) that analyzes patient assessment trends and vitals via Bedrock Claude to predict clinical decline before scores reach critical thresholds
- Extend notification system with `DETERIORATION_WARNING` and `DETERIORATION_CRITICAL` types, including amber/red alert styling in `NotificationBell`
- Add `DeteriorationRiskPanel` component and integrate "Analizar Riesgo de Deterioro" button into `PatientDashboard` clinical assessment section

## Details
- **Backend**: New Lambda queries PatientAssessment (byPatient GSI, last 7 days) and VitalSigns, pre-computes trends per clinical scale (direction, delta), sends Spanish-language prompt to Claude (temperature 0.3), and creates notifications for primary nurse + tenant admins on HIGH/CRITICAL risk
- **Schema**: Added `analyzeDeteriorationRisk` custom query and two new `NotificationType` enum values
- **IAM**: Bedrock invoke + DynamoDB access (Patient, PatientAssessment, VitalSigns, Notification, Nurse tables + indexes)
- **AWS Tags**: Verified all 102 resources have `auto-delete=no` and `application=EPS` — new Lambda inherits via `Tags.of(backend.stack)`
- **TypeScript**: Compiles cleanly with zero errors

## Test plan
- [ ] `npx ampx sandbox` deploys without errors
- [ ] Navigate to Patient Dashboard, select patient with 2+ assessments in last 7 days
- [ ] Click "Analizar Riesgo de Deterioro" — Lambda invokes and returns analysis JSON
- [ ] Verify DeteriorationRiskPanel renders risk level, trends, correlations, and summary
- [ ] If HIGH/CRITICAL risk detected, verify notification appears in NotificationBell with correct amber/red styling
- [ ] Test with patient having <2 assessments — should return "datos insuficientes" message
- [ ] Test with patient having stable-but-elevated scores — should return `hasRisk: false` (no false positives)
- [ ] Verify `auto-delete=no` and `application=EPS` tags on new Lambda in AWS Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)