### PR TITLE
fix(icons): replace invalid Activity import with Heartbeat

### DIFF
--- a/src/components/FeatureSection.tsx
+++ b/src/components/FeatureSection.tsx
@@ -1,12 +1,10 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { motion, AnimatePresence, useScroll } from 'framer-motion';
 import {
-    Activity,
-    CheckCircle,
+    Heartbeat,
     ShieldCheck,
     FileText,
     MapPin,
-    ChartBar,
     Warning,
     Invoice,
     FlowArrow,
@@ -27,7 +25,7 @@ const GlosasUI = () => (
             >
                 <div className="flex items-center gap-2 mb-2">
                     <div className="p-1.5 bg-emerald-100 text-emerald-600 rounded-md">
-                        <Activity size={16} />
+                        <Heartbeat size={16} />
                     </div>
                     <div className="text-slate-500 text-xs font-medium uppercase tracking-wider">Monto Recuperado</div>
                 </div>


### PR DESCRIPTION
## Summary
Fixes the Amplify build failure (job #225) caused by importing `Activity` from `@phosphor-icons/react` — that icon doesn't exist in the Phosphor library.

## Changes
- Replace `Activity` with `Heartbeat` (correct Phosphor equivalent)
- Remove unused `CheckCircle` and `ChartBar` imports

## What was tested
- Verified `Heartbeat` and `ShieldCheck` are valid Phosphor exports (confirmed via other working files in the codebase and Phosphor docs)
- Zero diagnostics/lint errors on the changed file

## Post-merge
After Amplify build succeeds, run the mandatory post-deploy fix from the EC2 instance:
```bash
bash .local-tests/post-deploy.sh
node .local-tests/e2e-full-workflow.cjs
```